### PR TITLE
Update Actions Versions in Workflows

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
     - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
 #      run: |
 #        pytest --cov-report=xml --cov=src/grpc_requests
 #    - name: Upload coverage to Codecov
-#      uses: codecov/codecov-action@v1
+#      uses: codecov/codecov-action@v3
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -29,4 +29,4 @@ jobs:
 #        run: |
 #          pytest --cov-report=xml --cov=src/grpc_requests
 #      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v1
+#        uses: codecov/codecov-action@v3


### PR DESCRIPTION
- Updates versions of checkout, setup-python, and code-cov to the latest versions.
- This addresses #10 
- [v3 of codecov isn't backwards compatible with v1](https://github.com/marketplace/actions/codecov#%EF%B8%8F--deprecation-of-v1), so developers should be aware of that when bringing code-cov back online in the future.