### PR TITLE
Update requirements to not use protobuf 4.22.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 grpcio>=1.49.1
 grpcio-reflection>=1.49.1
 google-api-core>=2.9.0
-cryptography>=39.0.0
+cryptography>=39.0.1
+protobuf==4.21.12


### PR DESCRIPTION
Adding this pin after a discovery today that the library may have issues with JSON in protobuf 4.22.0.
Along with a bump to the cryptography library to handle a [security issue](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#3901---2023-02-07).