### PR TITLE
Viridianforge/adjust protobuf req

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -620,6 +620,9 @@ paket-files/
 __pycache__/
 *.pyc
 
+# Ruff for VS Code
+.ruff_cache/
+
 # Cake - Uncomment if you are using it
 # tools/**
 # !tools/packages.config

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ grpcio>=1.53.0
 grpcio-reflection>=1.53.0
 google-api-core>=2.9.0
 cryptography>=39.0.1
-protobuf<=4.23.0

--- a/src/grpc_requests/__init__.py
+++ b/src/grpc_requests/__init__.py
@@ -1,4 +1,4 @@
 from .aio import AsyncClient, ReflectionAsyncClient, StubAsyncClient, get_by_endpoint as async_get_by_endpoint
 from .client import Client, ReflectionClient, StubClient, get_by_endpoint
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -2,7 +2,6 @@ import logging
 import sys
 from enum import Enum
 from functools import partial
-import importlib.metadata
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, TypeVar, Union
 
 import grpc
@@ -16,11 +15,16 @@ from .utils import describe_request, load_data
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict  # pylint: disable=no-name-in-module
+    import importlib.metadata as get_metadata
 else:
     from typing_extensions import TypedDict
+    
+    import pkg_resources
+    def get_metadata(package_name: str):
+        return pkg_resources.get_distribution(package_name).version
 
 # Import GetMessageClass if protobuf version supports it
-protobuf_minor_version = importlib.metadata.version('protobuf').split('.')[1]
+protobuf_minor_version = get_metadata('protobuf').split('.')[1]
 get_message_class_supported = int(protobuf_minor_version) >= 22
 if get_message_class_supported:
     from google.protobuf.message_factory import GetMessageClass

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -15,11 +15,14 @@ from .utils import describe_request, load_data
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict  # pylint: disable=no-name-in-module
-    import importlib.metadata as get_metadata
+    import importlib.metadata
+
+    def get_metadata(package_name: str):
+        return importlib.metadata.version(package_name)
 else:
     from typing_extensions import TypedDict
-    
     import pkg_resources
+
     def get_metadata(package_name: str):
         return pkg_resources.get_distribution(package_name).version
 

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -27,8 +27,8 @@ else:
         return pkg_resources.get_distribution(package_name).version
 
 # Import GetMessageClass if protobuf version supports it
-protobuf_minor_version = get_metadata('protobuf').split('.')[1]
-get_message_class_supported = int(protobuf_minor_version) >= 22
+protobuf_version = get_metadata('protobuf').split('.')
+get_message_class_supported = int(protobuf_version[0]) >= 4 and int(protobuf_version[1]) >= 22
 if get_message_class_supported:
     from google.protobuf.message_factory import GetMessageClass
 


### PR DESCRIPTION
- Removes protobuf version top pin
- Adds support for GetMessageClass if the version of protobuf installed supports it
- Beginning to consider removing support for deprecated versions (Python 3.7, Protobuf 4.21 in Q1 of 2024)