### PR TITLE
Add guard to prevent trying to add the same file multiple times

### DIFF
--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -363,26 +363,30 @@ class ReflectionAsyncClient(BaseAsyncGrpcClient):
         proto = result.file_descriptor_response.file_descriptor_proto[0]
         return descriptor_pb2.FileDescriptorProto.FromString(proto)
 
+    def _is_descriptor_registered(self, filename):
+        try:
+            self._desc_pool.FindFileByName(filename)
+        except KeyError:
+            return False
+        else:
+            logger.debug(f'{filename} already registered')
+            return True
+
     async def _register_file_descriptor(self, file_descriptor):
         logger.debug(f"start {file_descriptor.name} register")
-        try:
-            self._desc_pool.FindFileByName(file_descriptor.name)
-        except KeyError:
-            pass
-        else:
-            logger.debug(f'{file_descriptor.name} already registered')
+        if self._is_descriptor_registered(file_descriptor.name):
             return
         dependencies = list(file_descriptor.dependency)
         logger.debug(f"find {len(dependencies)} dependency in {file_descriptor.name}")
         for dep_file_name in dependencies:
-            if dep_file_name not in self.registered_file_names:
+            if not self._is_descriptor_registered(dep_file_name):
                 dep_desc = await self._get_file_descriptor_by_name(dep_file_name)
                 await self._register_file_descriptor(dep_desc)
                 self.registered_file_names.add(dep_file_name)
-            else:
-                logger.debug(f'{dep_file_name} already registered')
-
-        self._desc_pool.Add(file_descriptor)
+        try:
+            self._desc_pool.Add(file_descriptor)
+        except TypeError:
+            logger.debug(f"{file_descriptor.name} already present in pool. Skipping.")
         logger.debug(f"end {file_descriptor.name} register")
 
     async def register_service(self, service_name):

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -335,7 +335,6 @@ class ReflectionAsyncClient(BaseAsyncGrpcClient):
                  **kwargs):
         super().__init__(endpoint, symbol_db, descriptor_pool, ssl=ssl, compression=compression, **kwargs)
         self.reflection_stub = reflection_pb2_grpc.ServerReflectionStub(self.channel)
-        self.registered_file_names = set()
 
     def _reflection_request(self, *requests):
         responses = self.reflection_stub.ServerReflectionInfo((r for r in requests))
@@ -382,7 +381,6 @@ class ReflectionAsyncClient(BaseAsyncGrpcClient):
             if not self._is_descriptor_registered(dep_file_name):
                 dep_desc = await self._get_file_descriptor_by_name(dep_file_name)
                 await self._register_file_descriptor(dep_desc)
-                self.registered_file_names.add(dep_file_name)
         try:
             self._desc_pool.Add(file_descriptor)
         except TypeError:

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -365,6 +365,13 @@ class ReflectionAsyncClient(BaseAsyncGrpcClient):
 
     async def _register_file_descriptor(self, file_descriptor):
         logger.debug(f"start {file_descriptor.name} register")
+        try:
+            self._desc_pool.FindFileByName(file_descriptor.name)
+        except KeyError:
+            pass
+        else:
+            logger.debug(f'{file_descriptor.name} already registered')
+            return
         dependencies = list(file_descriptor.dependency)
         logger.debug(f"find {len(dependencies)} dependency in {file_descriptor.name}")
         for dep_file_name in dependencies:

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -352,7 +352,6 @@ class ReflectionClient(BaseGrpcClient):
                  **kwargs):
         super().__init__(endpoint, symbol_db, descriptor_pool, ssl=ssl, lazy=lazy, compression=compression, **kwargs)
         self.reflection_stub = reflection_pb2_grpc.ServerReflectionStub(self.channel)
-        self.registered_file_names = set()
         if not self._lazy:
             self.register_all_service()
 
@@ -403,7 +402,6 @@ class ReflectionClient(BaseGrpcClient):
             if not self._is_descriptor_registered(dep_file_name):
                 dep_desc = self._get_file_descriptor_by_name(dep_file_name)
                 self._register_file_descriptor(dep_desc)
-                self.registered_file_names.add(dep_file_name)
         try:
             self._desc_pool.Add(file_descriptor)
         except TypeError:


### PR DESCRIPTION
When using a complex server with multiple services that may both rely on the same file (timestamp.proto for example) the file would get added to the descriptor pool twice. This prevents that.

I don't have a great way to test it with the current framework, ideally you would add some services to the test protos that each used a timestamp as an argument. But it works when I test it against a real server.