### PR TITLE
Add methods-meta property exposing method metadata

### DIFF
--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -420,6 +420,11 @@ class StubAsyncClient(BaseAsyncGrpcClient):
 
 
 class ServiceClient:
+    _method_names: Tuple[str, ...]
+    _methods_meta: Dict[str, MethodMetaData]
+    client: BaseAsyncGrpcClient
+    name: str
+
     def __init__(self, client: BaseAsyncGrpcClient, service_name: str):
         self.client = client
         self.name = service_name
@@ -442,6 +447,10 @@ class ServiceClient:
     @property
     def method_names(self):
         return self._method_names
+
+    @property
+    def methods_meta(self):
+        return self._methods_meta
 
 
 AsyncClient = ReflectionAsyncClient

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -447,6 +447,11 @@ class StubClient(BaseGrpcClient):
 
 
 class ServiceClient:
+    _method_names: Tuple[str, ...]
+    _methods_meta: Dict[str, MethodMetaData]
+    client: BaseGrpcClient
+    name: str
+
     def __init__(self, client: BaseGrpcClient, service_name: str):
         self.client = client
         self.name = service_name
@@ -461,6 +466,10 @@ class ServiceClient:
     @property
     def method_names(self):
         return self._method_names
+
+    @property
+    def methods_meta(self):
+        return self._methods_meta
 
 
 Client = ReflectionClient

--- a/src/tests/async_reflection_client_test.py
+++ b/src/tests/async_reflection_client_test.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from grpc_requests.aio import AsyncClient
+from grpc_requests.aio import AsyncClient, MethodType
 from google.protobuf.json_format import ParseError
 
 from tests.common import AsyncMetadataClientInterceptor
@@ -27,6 +27,13 @@ async def test_unary_unary_interceptor():
     response = await greeter_service.SayHello({"name": "sinsky"})
     assert isinstance(response, dict)
     assert response == {"message": "Hello, sinsky, interceptor accepted!"}
+
+@pytest.mark.asyncio
+async def test_methods_meta():
+    client = AsyncClient('localhost:50051', interceptors=[AsyncMetadataClientInterceptor()])
+    greeter_service = await client.service('helloworld.Greeter')
+    meta = greeter_service.methods_meta
+    assert meta['HelloEveryone'].method_type == MethodType.STREAM_UNARY
 
 @pytest.mark.asyncio
 async def test_empty_body_request():

--- a/src/tests/reflection_client_test.py
+++ b/src/tests/reflection_client_test.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from grpc_requests.client import Client
+from grpc_requests.client import Client, MethodType
 from google.protobuf.json_format import ParseError
 
 from tests.common import MetadataClientInterceptor
@@ -54,6 +54,10 @@ def test_interceptor_usage(helloworld_reflection_client_with_interceptor):
     assert isinstance(response, dict)
     assert response == {"message": "Hello, sinsky, interceptor accepted!"}
 
+def test_methods_meta(helloworld_reflection_client):
+    service = helloworld_reflection_client.service('helloworld.Greeter')
+    meta = service.methods_meta
+    assert meta['HelloEveryone'].method_type == MethodType.STREAM_UNARY
 
 def test_unary_unary(helloworld_reflection_client):
     response = helloworld_reflection_client.request('helloworld.Greeter', 'SayHello', {"name": "sinsky"})


### PR DESCRIPTION
This seemed like the best way to expose method metadata on a service client. Added a test for it and some static typing in the service client object for a bit more clarity.