### PR TITLE
Loosen up protobuf a bit more

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 grpcio
 grpcio-reflection
-protobuf<4
+protobuf>=3.20.3
 google-api-core>=2.9.0
 cryptography>=39.0.1


### PR DESCRIPTION
Flipping up the protobuf requirement to be loosened, but greater than or equal to `3.20.3`

For @artificial-aidan (since this is related to your suggestion) - realized that in my haste - some users of the library (myself included) are using `protobuf` > 4.  I figure than `3.20.3` is fair given that per [the protobuf version support chart](https://protobuf.dev/support/version-support/) - `3.21.x` is going out of support in Q1 of 2024, and then then 4 version line will be what's supported going forward.