### PR TITLE
Add lazy loading option for services on async client

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,3 +56,5 @@ addopts =
     --verbose
 testpaths =
     src/tests
+pythonpath =
+    src

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -143,6 +143,22 @@ client = Client(
 
 [Review the json_format documentation for what kwargs are available to message_to_dict.](https://googleapis.dev/python/protobuf/latest/google/protobuf/json_format.html)
 
+## Creating an async lazy client
+An async lazy client can be used to improve startup performance, because the client doesn't need to perform some actions (like service discovery and method registration) during initialization.
+You can choose whether to use a lazy client or a non-lazy client based on your program's specific requirements. If you're sure that you'll need to use all of the client's operations as soon as the client is created, then a non-lazy (eager) client might be more suitable. If you only need to use certain operations and you're not sure when you'll need to use them, then a lazy client might be a better choice.
+```python
+from grpc_requests.aio import AsyncClient
+
+client_lazy = AsyncClient("localhost:50051", lazy=True)
+await client_lazy.get_methods_meta("helloworld.Greeter")
+print(f"INFO: registered service methods length for lazy client: {len(client_lazy._service_methods_meta)}")
+
+client_nonlazy = AsyncClient("localhost:50051", lazy=False)
+await client_nonlazy.get_methods_meta("helloworld.Greeter")
+print(f"INFO: registered service methods length for non-lazy client: {len(client_nonlazy._service_methods_meta)}")
+```
+
+
 ## Retrieving Information about a Server
 
 All forms of clients expose methods to allow a user to query a server about its

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -13,8 +13,6 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
-    Type,
-    Union,
 )
 
 import grpc
@@ -270,15 +268,15 @@ MethodTypeMatch: Dict[Tuple[IS_REQUEST_STREAM, IS_RESPONSE_STREAM], MethodType] 
 
 class BaseAsyncGrpcClient(BaseAsyncClient):
     def __init__(
-            self,
-            endpoint,
-            symbol_db=None,
-            descriptor_pool=None,
-            lazy=True,
-            ssl=False,
-            compression=None,
-            skip_check_method_available=False,
-            message_parsers: MessageParsersProtocol = MessageParsers(),
+        self,
+        endpoint,
+        symbol_db=None,
+        descriptor_pool=None,
+        lazy=True,
+        ssl=False,
+        compression=None,
+        skip_check_method_available=False,
+        message_parsers: MessageParsersProtocol = MessageParsers(),
         **kwargs,
     ):
         super().__init__(
@@ -401,9 +399,9 @@ class BaseAsyncGrpcClient(BaseAsyncClient):
             await self.register_all_service()
 
         if (
-                self._lazy
-                and service_name in await self.service_names()
-                and service_name not in self._service_methods_meta
+            self._lazy
+            and service_name in await self.service_names()
+            and service_name not in self._service_methods_meta
         ):
             await self.register_service(service_name)
 
@@ -416,7 +414,9 @@ class BaseAsyncGrpcClient(BaseAsyncClient):
     def _make_method_full_name(service: str, method: str):
         return f"/{service}/{method}"
 
-    async def _request(self, service: str, method: str, request, raw_output=False, **kwargs):
+    async def _request(
+        self, service: str, method: str, request, raw_output=False, **kwargs
+    ):
         # does not check request is available
         method_meta = await self.get_method_meta(service, method)
 
@@ -432,7 +432,9 @@ class BaseAsyncGrpcClient(BaseAsyncClient):
             result = method_meta.handler(_request, **kwargs)
             return method_meta.response_parser(result)
 
-    async def request(self, service: str, method: str, request=None, raw_output=False, **kwargs):
+    async def request(
+        self, service: str, method: str, request=None, raw_output=False, **kwargs
+    ):
         await self.check_method_available(service, method)
         return await self._request(service, method, request, raw_output, **kwargs)
 
@@ -448,7 +450,9 @@ class BaseAsyncGrpcClient(BaseAsyncClient):
         await self.check_method_available(service, method, MethodType.UNARY_STREAM)
         return await self._request(service, method, request, raw_output, **kwargs)
 
-    async def stream_unary(self, service: str, method: str, requests, raw_output=False, **kwargs):
+    async def stream_unary(
+        self, service: str, method: str, requests, raw_output=False, **kwargs
+    ):
         await self.check_method_available(service, method, MethodType.STREAM_UNARY)
         return await self._request(service, method, requests, raw_output, **kwargs)
 
@@ -471,9 +475,9 @@ class BaseAsyncGrpcClient(BaseAsyncClient):
             await self.register_all_service()
 
         if (
-                self._lazy
-                and service in await self.service_names()
-                and service not in self._service_methods_meta
+            self._lazy
+            and service in await self.service_names()
+            and service not in self._service_methods_meta
         ):
             await self.register_service(service)
 
@@ -501,14 +505,14 @@ class BaseAsyncGrpcClient(BaseAsyncClient):
 
 class ReflectionAsyncClient(BaseAsyncGrpcClient):
     def __init__(
-            self,
-            endpoint,
-            symbol_db=None,
-            descriptor_pool=None,
-            lazy=True,
-            ssl=False,
-            compression=None,
-            message_parsers: MessageParsersProtocol = MessageParsers(),
+        self,
+        endpoint,
+        symbol_db=None,
+        descriptor_pool=None,
+        lazy=True,
+        ssl=False,
+        compression=None,
+        message_parsers: MessageParsersProtocol = MessageParsers(),
         **kwargs,
     ):
         super().__init__(
@@ -642,15 +646,15 @@ class ReflectionAsyncClient(BaseAsyncGrpcClient):
 
 class StubAsyncClient(BaseAsyncGrpcClient):
     def __init__(
-            self,
-            endpoint,
-            service_descriptors: List[ServiceDescriptor],
-            symbol_db=None,
-            lazy=False,
-            descriptor_pool=None,
-            ssl=False,
-            compression=None,
-            **kwargs,
+        self,
+        endpoint,
+        service_descriptors: List[ServiceDescriptor],
+        symbol_db=None,
+        lazy=False,
+        descriptor_pool=None,
+        ssl=False,
+        compression=None,
+        **kwargs,
     ):
         super().__init__(
             endpoint,

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-import warnings
 from enum import Enum
 from functools import partial
 from typing import (

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -630,19 +630,6 @@ class ReflectionAsyncClient(BaseAsyncGrpcClient):
             logger.debug(f"{service_name} registration complete")
         await super(ReflectionAsyncClient, self).register_service(service_name)
 
-    async def refresh_service_registrations(self):
-        """
-        Clears the existing registered services and freshly re-registers them.
-        Useful if the gRPC server adds or removes services dynamically.
-
-        Regular re-registration helps ensure the client's service registry remains
-        synchronized with the current state of the server, thus accommodating
-        service changes that occur during the lifespan of the connection.
-        """
-        self._service_methods_meta.clear()
-        self.has_server_registered = False
-        await self.register_all_service()
-
 
 class StubAsyncClient(BaseAsyncGrpcClient):
     def __init__(

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -471,7 +471,7 @@ class BaseAsyncGrpcClient(BaseAsyncClient):
 
     async def get_method_meta(self, service: str, method: str) -> MethodMetaData:
         # add lazy mode & exception
-        if self._lazy is False and not self.has_server_registered:
+        if not self._lazy and not self.has_server_registered:
             await self.register_all_service()
 
         if (

--- a/src/grpc_requests/aio.py
+++ b/src/grpc_requests/aio.py
@@ -626,6 +626,19 @@ class ReflectionAsyncClient(BaseAsyncGrpcClient):
             logger.debug(f"{service_name} registration complete")
         await super(ReflectionAsyncClient, self).register_service(service_name)
 
+    async def refresh_service_registrations(self):
+        """
+        Clears the existing registered services and freshly re-registers them.
+        Useful if the gRPC server adds or removes services dynamically.
+
+        Regular re-registration helps ensure the client's service registry remains
+        synchronized with the current state of the server, thus accommodating
+        service changes that occur during the lifespan of the connection.
+        """
+        self._service_methods_meta.clear()
+        self.has_server_registered = False
+        await self.register_all_service()
+
 
 class StubAsyncClient(BaseAsyncGrpcClient):
     def __init__(

--- a/src/grpc_requests/client.py
+++ b/src/grpc_requests/client.py
@@ -562,7 +562,7 @@ class ReflectionClient(BaseGrpcClient):
             )
             for dep_file_name in dependencies:
                 if not self._is_descriptor_registered(dep_file_name):
-                    # First look for dependency in the passed in descriptors
+                    # First look for dependency in the passed descriptors
                     dep_desc = next(
                         (x for x in file_descriptors if x.name == dep_file_name), None
                     )

--- a/src/tests/async_reflection_client_test.py
+++ b/src/tests/async_reflection_client_test.py
@@ -27,8 +27,7 @@ reflection_service_name = "grpc.reflection.v1alpha.ServerReflection"
 @pytest.mark.asyncio
 async def test_unary_unary():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     response = await greeter_service.SayHello({"name": "sinsky"})
@@ -64,8 +63,7 @@ async def test_methods_meta():
 @pytest.mark.asyncio
 async def test_empty_body_request():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     response = await greeter_service.SayHello({})
@@ -75,8 +73,7 @@ async def test_empty_body_request():
 @pytest.mark.asyncio
 async def test_nonexistent_method():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     with pytest.raises(AttributeError):
@@ -86,8 +83,7 @@ async def test_nonexistent_method():
 @pytest.mark.asyncio
 async def test_unsupported_argument():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     with pytest.raises(ParseError):
@@ -97,8 +93,7 @@ async def test_unsupported_argument():
 @pytest.mark.asyncio
 async def test_unary_stream():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     name_list = ["sinsky", "viridianforge", "jack", "harry"]
@@ -116,8 +111,7 @@ async def test_unary_stream():
 @pytest.mark.asyncio
 async def test_stream_unary():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     name_list = ["sinsky", "viridianforge", "jack", "harry"]
@@ -133,8 +127,7 @@ async def test_stream_unary():
 @pytest.mark.asyncio
 async def test_stream_stream():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     name_list = ["sinsky", "viridianforge", "jack", "harry"]
@@ -152,8 +145,7 @@ async def test_stream_stream():
 @pytest.mark.asyncio
 async def test_reflection_service_client():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     method_names = greeter_service.method_names
@@ -168,8 +160,7 @@ async def test_reflection_service_client():
 @pytest.mark.asyncio
 async def test_reflection_service_client_invalid_service():
     client = AsyncClient(
-        "localhost:50051",
-        descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
     )
     with pytest.raises(ValueError):
         await client.service("helloWorld.Singer")

--- a/src/tests/async_reflection_client_test.py
+++ b/src/tests/async_reflection_client_test.py
@@ -21,13 +21,14 @@ Test cases for async reflection based client
 """
 
 logger = logging.getLogger("name")
-reflection_service_name = 'grpc.reflection.v1alpha.ServerReflection'
+reflection_service_name = "grpc.reflection.v1alpha.ServerReflection"
 
 
 @pytest.mark.asyncio
 async def test_unary_unary():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     response = await greeter_service.SayHello({"name": "sinsky"})
@@ -63,7 +64,8 @@ async def test_methods_meta():
 @pytest.mark.asyncio
 async def test_empty_body_request():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     response = await greeter_service.SayHello({})
@@ -73,7 +75,8 @@ async def test_empty_body_request():
 @pytest.mark.asyncio
 async def test_nonexistent_method():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     with pytest.raises(AttributeError):
@@ -83,7 +86,8 @@ async def test_nonexistent_method():
 @pytest.mark.asyncio
 async def test_unsupported_argument():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     with pytest.raises(ParseError):
@@ -93,7 +97,8 @@ async def test_unsupported_argument():
 @pytest.mark.asyncio
 async def test_unary_stream():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     name_list = ["sinsky", "viridianforge", "jack", "harry"]
@@ -111,7 +116,8 @@ async def test_unary_stream():
 @pytest.mark.asyncio
 async def test_stream_unary():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     name_list = ["sinsky", "viridianforge", "jack", "harry"]
@@ -127,7 +133,8 @@ async def test_stream_unary():
 @pytest.mark.asyncio
 async def test_stream_stream():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     name_list = ["sinsky", "viridianforge", "jack", "harry"]
@@ -145,7 +152,8 @@ async def test_stream_stream():
 @pytest.mark.asyncio
 async def test_reflection_service_client():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     greeter_service = await client.service("helloworld.Greeter")
     method_names = greeter_service.method_names
@@ -160,7 +168,8 @@ async def test_reflection_service_client():
 @pytest.mark.asyncio
 async def test_reflection_service_client_invalid_service():
     client = AsyncClient(
-        "localhost:50051", descriptor_pool=descriptor_pool.DescriptorPool()
+        "localhost:50051",
+        descriptor_pool=descriptor_pool.DescriptorPool()
     )
     with pytest.raises(ValueError):
         await client.service("helloWorld.Singer")
@@ -364,14 +373,16 @@ async def test_unary_stream_empty():
 @pytest.mark.asyncio
 async def test_services_are_not_registered_when_using_lazy_client():
     client = AsyncClient("localhost:50051")
-    await client.get_method_meta(reflection_service_name, 'ServerReflectionInfo')
+    await client.get_method_meta(reflection_service_name, "ServerReflectionInfo")
     assert client.has_server_registered is False
 
 
 @pytest.mark.asyncio
 async def test_can_get_method_meta_for_reflection_service_when_using_lazy_client():
     client = AsyncClient("localhost:50051")
-    response = await client.get_method_meta(reflection_service_name, 'ServerReflectionInfo')
+    response = await client.get_method_meta(
+        reflection_service_name, "ServerReflectionInfo"
+    )
     assert isinstance(response, MethodMetaData)
     assert response.input_type == reflection_pb2.ServerReflectionRequest
     assert response.output_type == reflection_pb2.ServerReflectionResponse
@@ -381,7 +392,9 @@ async def test_can_get_method_meta_for_reflection_service_when_using_lazy_client
 @pytest.mark.asyncio
 async def test_can_get_method_meta_for_reflection_service_when_using_non_lazy_client():
     client = AsyncClient("localhost:50051", lazy=False)
-    response = await client.get_method_meta(reflection_service_name, 'ServerReflectionInfo')
+    response = await client.get_method_meta(
+        reflection_service_name, "ServerReflectionInfo"
+    )
     assert isinstance(response, MethodMetaData)
     assert response.input_type == reflection_pb2.ServerReflectionRequest
     assert response.output_type == reflection_pb2.ServerReflectionResponse

--- a/src/tests/async_reflection_client_test.py
+++ b/src/tests/async_reflection_client_test.py
@@ -364,8 +364,8 @@ async def test_unary_stream_empty():
 @pytest.mark.asyncio
 async def test_services_are_not_registered_when_using_lazy_client():
     client = AsyncClient("localhost:50051")
-    with pytest.raises(KeyError, match=reflection_service_name):
-        await client.get_method_meta(reflection_service_name, 'ServerReflectionInfo')
+    await client.get_method_meta(reflection_service_name, 'ServerReflectionInfo')
+    assert client.has_server_registered is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add lazy loading option for services on async client. Using the async client by endpoint, defaults to non-lazy service registering. Add two tests for the cases lazy and non-lazy services registering.

---
I refactored this in order to prevent an error I was getting when trying to run this code:

```import asyncio

from grpc_requests import AsyncClient


async def main():
    client = AsyncClient.get_by_endpoint("localhost:50055")
    service = 'reflection.Service'
    method = "ServerReflectionInfo"
    # methods_meta = await client.get_methods_meta(service)
    # print(methods_meta)
    method_meta = client.get_method_meta(service, method)
    print(method_meta.method_type)


asyncio.run(main())
```

```
Traceback (most recent call last):
  File "/home/cristi/Projects/backend-proxy/backend_proxy/script.py", line 16, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 685, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/cristi/Projects/backend-proxy/backend_proxy/script.py", line 12, in main
    method_meta = client.get_method_meta(service, method)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cristi/Projects/backend-proxy/.venv/lib/python3.12/site-packages/grpc_requests/aio.py", line 400, in get_method_meta
    return self._service_methods_meta[service][method]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'reflection.Service'
```