### PR TITLE
Update versions in gha actions

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -11,11 +11,11 @@ jobs:
       id-token: write    
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -23,15 +23,15 @@ jobs:
         pip install -e .
     - name: Lint and check formatting with ruff
       run: |
-        ruff check src/grpc_requests/*.py src/tests/*.py --statistics
-        ruff format src/grpc_requests/*.py src/tests/*.py --check
+        ruff check src/grpc_requests/*.py src/tests/*.py --statistics --config ruff.toml
+        ruff format src/grpc_requests/*.py src/tests/*.py --check --config ruff.toml
     - name: Test with pytest
       run: |
         pytest --cov-report=xml --cov=src/grpc_requests
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
     - name: Build
       run: |
         python setup.py sdist bdist_wheel      
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.11
+      uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -25,8 +25,8 @@ jobs:
           pip install -e .
       - name: Lint and check formatting with ruff
         run: |
-          ruff check src/grpc_requests/*.py src/tests/*.py --statistics
-          ruff format src/grpc_requests/*.py src/tests/*.py --check
+          ruff check src/grpc_requests/*.py src/tests/*.py --statistics --config ruff.toml
+          ruff format src/grpc_requests/*.py src/tests/*.py --check --config ruff.toml
       - name: Test with pytest
         run: |
           pytest --cov-report=xml --cov=src/grpc_requests


### PR DESCRIPTION
- Update versions of actions used in workflows
- Set baseline python version to 3.9, matching future baseline version
- Add ruff config to linting and formatting tests